### PR TITLE
Feature/create event front

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -3,10 +3,12 @@ import { Login } from './pages/login/login';
 import { Home } from './pages/home/home';
 import { Register } from './pages/register/register';
 import { CreateEventPage } from './pages/create-event/create-event';
+import { InviteEventPage } from './pages/invite-event/invite-event';
 
 export const routes: Routes = [
   { path: '', component: Home },
   { path: 'login', component: Login },
   { path: 'register', component: Register },
-  { path: 'event', component: CreateEventPage }
+  { path: 'event', component: CreateEventPage },
+  { path: 'event/:id/invite', component: InviteEventPage }
 ];

--- a/frontend/src/app/components/calendar-card/calendar-card.html
+++ b/frontend/src/app/components/calendar-card/calendar-card.html
@@ -4,6 +4,10 @@
       <span class="bi bi-calendar3"></span>
       Calendario
     </div>
+    <div class="ev-cal__nav">
+      <button class="ev-cal__btn" (click)="prevMonth()" title="Mes anterior"><span class="bi bi-chevron-left"></span></button>
+      <button class="ev-cal__btn" (click)="nextMonth()" title="Mes siguiente"><span class="bi bi-chevron-right"></span></button>
+    </div>
   </div>
   <div class="ev-cal__body">
     <div class="ev-cal__month">{{ monthDate | date:'MMMM yyyy' }}</div>

--- a/frontend/src/app/components/calendar-card/calendar-card.html
+++ b/frontend/src/app/components/calendar-card/calendar-card.html
@@ -16,7 +16,8 @@
            [class.ev-cal__cell--empty]="day === null"
            [class.ev-cal__cell--has]="day && hasEventOn(day)"
            [class.ev-cal__cell--today]="day && isToday(day)">
-        <span>{{ day || '' }}</span>
+        <span class="ev-cal__daynum">{{ day || '' }}</span>
+        <span *ngIf="day && hasEventOn(day)" class="ev-cal__dot"></span>
       </div>
     </div>
   </div>

--- a/frontend/src/app/components/calendar-card/calendar-card.scss
+++ b/frontend/src/app/components/calendar-card/calendar-card.scss
@@ -13,7 +13,9 @@
 .ev-cal__days { display:grid; grid-template-columns: repeat(7, 1fr); gap: 4px; margin-bottom:6px; color:#94a3b8; font-size:12px; }
 .ev-cal__dow { text-align:center; }
 .ev-cal__grid { display:grid; grid-template-columns: repeat(7, 1fr); gap: 6px; }
-.ev-cal__cell { height: 34px; border:1px dashed rgba(148,163,184,0.15); border-radius:8px; display:flex; align-items:center; justify-content:center; color:#94a3b8; font-size:12px; }
+.ev-cal__cell { height: 36px; border:1px dashed rgba(148,163,184,0.15); border-radius:10px; display:flex; align-items:center; justify-content:center; color:#94a3b8; font-size:12px; position: relative; transition: background .15s ease, border-color .15s ease; }
+.ev-cal__daynum { position: relative; z-index: 1; }
+.ev-cal__dot { position: absolute; bottom: 5px; width: 6px; height: 6px; border-radius: 999px; background: #93c5fd; box-shadow: 0 0 0 2px rgba(147,197,253,0.15); }
 .ev-cal__cell--empty { background: rgba(148,163,184,0.05); }
-.ev-cal__cell--has { border-color: rgba(99,102,241,0.6); color:#c7d2fe; background: rgba(99,102,241,0.12); }
-.ev-cal__cell--today { outline: 2px solid #22d3ee; outline-offset: -3px; }
+.ev-cal__cell--has { border-color: rgba(99,102,241,0.6); color:#c7d2fe; background: rgba(99,102,241,0.1); }
+.ev-cal__cell--today { outline: 2px solid #22d3ee; outline-offset: -3px; box-shadow: 0 0 12px rgba(34,211,238,0.25) inset; }

--- a/frontend/src/app/components/calendar-card/calendar-card.scss
+++ b/frontend/src/app/components/calendar-card/calendar-card.scss
@@ -16,6 +16,11 @@
 .ev-cal__cell { height: 36px; border:1px dashed rgba(148,163,184,0.15); border-radius:10px; display:flex; align-items:center; justify-content:center; color:#94a3b8; font-size:12px; position: relative; transition: background .15s ease, border-color .15s ease; }
 .ev-cal__daynum { position: relative; z-index: 1; }
 .ev-cal__dot { position: absolute; bottom: 5px; width: 6px; height: 6px; border-radius: 999px; background: #93c5fd; box-shadow: 0 0 0 2px rgba(147,197,253,0.15); }
+.ev-cal__cell--has .ev-cal__dot { animation: pulseDot 1.8s ease-in-out infinite; }
+@keyframes pulseDot { 0%,100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.35); opacity: .85; } }
+
+.ev-cal__grid .ev-cal__cell { animation: fadeInCell .35s ease both; }
+@keyframes fadeInCell { from { opacity: 0; transform: translateY(4px);} to { opacity: 1; transform: none; } }
 .ev-cal__cell--empty { background: rgba(148,163,184,0.05); }
 .ev-cal__cell--has { border-color: rgba(99,102,241,0.6); color:#c7d2fe; background: rgba(99,102,241,0.1); }
 .ev-cal__cell--today { outline: 2px solid #22d3ee; outline-offset: -3px; box-shadow: 0 0 12px rgba(34,211,238,0.25) inset; }

--- a/frontend/src/app/components/calendar-card/calendar-card.ts
+++ b/frontend/src/app/components/calendar-card/calendar-card.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Event } from '../../models/event.model';
 
@@ -9,7 +9,7 @@ import { Event } from '../../models/event.model';
   templateUrl: './calendar-card.html',
   styleUrls: ['./calendar-card.scss']
 })
-export class CalendarCard implements OnChanges {
+export class CalendarCard implements OnChanges, OnInit {
   @Input() events: Event[] = [];
 
   currentYear = new Date().getFullYear();
@@ -20,6 +20,10 @@ export class CalendarCard implements OnChanges {
     if (changes['events']) {
       this.buildCalendar();
     }
+  }
+
+  ngOnInit(): void {
+    this.buildCalendar();
   }
 
   get monthDate(): Date { return new Date(this.currentYear, this.currentMonth, 1); }
@@ -52,7 +56,34 @@ export class CalendarCard implements OnChanges {
     for (let i = 0; i < startOffset; i++) cells.push(null);
     for (let d = 1; d <= daysInMonth; d++) cells.push(d);
     while (cells.length % 7 !== 0) cells.push(null);
-    while (cells.length < 42) cells.push(null);
-    this.calendarCells = cells;
+    // Cap to 5 weeks (35 cells) as requested
+    if (cells.length > 35) {
+      this.calendarCells = cells.slice(0, 35);
+    } else if (cells.length < 35) {
+      while (cells.length < 35) cells.push(null);
+      this.calendarCells = cells;
+    } else {
+      this.calendarCells = cells;
+    }
+  }
+
+  nextMonth() {
+    if (this.currentMonth === 11) {
+      this.currentMonth = 0;
+      this.currentYear += 1;
+    } else {
+      this.currentMonth += 1;
+    }
+    this.buildCalendar();
+  }
+
+  prevMonth() {
+    if (this.currentMonth === 0) {
+      this.currentMonth = 11;
+      this.currentYear -= 1;
+    } else {
+      this.currentMonth -= 1;
+    }
+    this.buildCalendar();
   }
 }

--- a/frontend/src/app/components/event-card/event-card.html
+++ b/frontend/src/app/components/event-card/event-card.html
@@ -10,8 +10,11 @@
       <span>{{ event.location }}</span>
     </div>
   </div>
-  <div class="ev-card__footer" *ngIf="isOwner">
+  <div class="ev-card__footer" *ngIf="isOwner" style="display:flex; justify-content: space-between; align-items:center; gap:8px;">
     <span class="pill">Organizas este evento</span>
+    <button class="btn btn-sm btn-light" (click)="onInviteClick()">
+      <span class="bi bi-person-plus"></span> Invitar
+    </button>
   </div>
   <div class="ev-card__footer" *ngIf="!isOwner">
     <span class="pill">Estás invitado</span>

--- a/frontend/src/app/components/event-card/event-card.ts
+++ b/frontend/src/app/components/event-card/event-card.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Event } from '../../models/event.model';
 
@@ -12,4 +12,11 @@ import { Event } from '../../models/event.model';
 export class EventCard {
   @Input() event!: Event;
   @Input() isOwner: boolean = false; // para mostrar diferentes acciones según si es dueño o invitado
+  @Output() invite = new EventEmitter<string>();
+
+  onInviteClick() {
+    if (this.event?.id) {
+      this.invite.emit(this.event.id);
+    }
+  }
 }

--- a/frontend/src/app/components/navbar/navbar.html
+++ b/frontend/src/app/components/navbar/navbar.html
@@ -4,8 +4,6 @@
       <a routerLink="/" class="brand">POV WebApp</a>
       <nav class="nav-links">
         <a routerLink="/" routerLinkActive="active" class="nav-link">Inicio</a>
-        <a routerLink="/acerca" routerLinkActive="active" class="nav-link">Acerca</a>
-        <a routerLink="/contacto" routerLinkActive="active" class="nav-link">Contacto</a>
         <button class="btn-logout" (click)="logout()">
           <span class="bi bi-box-arrow-right"></span>
           Cerrar sesión

--- a/frontend/src/app/components/navbar/navbar.scss
+++ b/frontend/src/app/components/navbar/navbar.scss
@@ -1,0 +1,48 @@
+.nav-shell {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  backdrop-filter: saturate(140%) blur(10px);
+  background: linear-gradient(180deg, rgba(11,18,32,0.8), rgba(11,18,32,0.6));
+  border-bottom: 1px solid rgba(148,163,184,0.12);
+}
+
+.nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 0;
+}
+
+.brand {
+  font-weight: 800;
+  color: #e2e8f0;
+  text-decoration: none;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.nav-link {
+  color: #cbd5e1;
+  text-decoration: none;
+  padding: 8px 10px;
+  border-radius: 8px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.nav-link:hover { background: rgba(148,163,184,0.12); color: #fff; }
+.nav-link.active { background: rgba(99,102,241,0.25); color: #fff; }
+
+.btn-logout {
+  border: 1px solid rgba(226,232,240,0.18);
+  color: #e2e8f0;
+  background: rgba(226,232,240,0.06);
+  border-radius: 10px;
+  padding: 8px 12px;
+}
+.btn-logout:hover { background: rgba(226,232,240,0.12); }

--- a/frontend/src/app/components/stats-panel/stats-panel.html
+++ b/frontend/src/app/components/stats-panel/stats-panel.html
@@ -1,20 +1,33 @@
 <div class="stats fade-in">
-  <div class="stat-card">
-    <h3>Invitado</h3>
-    <p>{{ invitedCount }}</p>
+  <div class="stat-card stat-invited">
+    <div class="stat-top">
+      <span class="bi bi-person-check"></span>
+      <h3>Invitado</h3>
+    </div>
+    <p class="stat-value">{{ invitedCount }}</p>
   </div>
-  <div class="stat-card">
-    <h3>Propios</h3>
-    <p>{{ ownedCount }}</p>
+
+  <div class="stat-card stat-owned">
+    <div class="stat-top">
+      <span class="bi bi-star"></span>
+      <h3>Propios</h3>
+    </div>
+    <p class="stat-value">{{ ownedCount }}</p>
   </div>
-  <div class="stat-card">
-    <h3>Total del mes</h3>
-    <p>{{ monthlyTotal }}</p>
+
+  <div class="stat-card stat-total">
+    <div class="stat-top">
+      <span class="bi bi-bar-chart"></span>
+      <h3>Total del mes</h3>
+    </div>
+    <p class="stat-value">{{ monthlyTotal }}</p>
   </div>
-  <div class="stat-card">
-    <h3>Próximo evento</h3>
-    <p class="pill">
-      <span class="bi bi-clock"></span> {{ nextEventLabel }}
-    </p>
+
+  <div class="stat-card stat-next">
+    <div class="stat-top">
+      <span class="bi bi-clock-history"></span>
+      <h3>Próximo evento</h3>
+    </div>
+    <p class="pill"><span class="bi bi-clock"></span> {{ nextEventLabel }}</p>
   </div>
 </div>

--- a/frontend/src/app/components/stats-panel/stats-panel.scss
+++ b/frontend/src/app/components/stats-panel/stats-panel.scss
@@ -1,41 +1,20 @@
-.stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
-  margin: 24px 0 8px;
-}
+.stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; margin: 24px 0 8px; }
 .fade-in { animation: fadeIn .35s ease both; }
 @keyframes fadeIn { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+.stat-card { background: #0b1220; color: #e2e8f0; border: 1px solid rgba(226,232,240,0.08); border-radius: 12px; padding: 16px; transition: transform .18s ease, box-shadow .2s ease, border-color .2s ease; }
+.stat-card:hover { transform: translateY(-2px); box-shadow: 0 10px 28px rgba(79,70,229,0.2); border-color: rgba(99,102,241,0.25); }
+.stat-top { display:flex; align-items:center; gap:8px; margin-bottom:6px; }
+.stat-top .bi { color:#93c5fd; }
+.stat-card h3 { font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; margin: 0; color: #93c5fd; font-weight: 600; }
+.stat-value { font-size: 28px; font-weight: 700; margin: 2px 0 0; }
+.pill { display: inline-flex; align-items: center; gap: 6px; background: rgba(255,255,255,0.15); color: #fff; border-radius: 999px; padding: 6px 10px; font-size: 12px; }
 
-.stat-card {
-  background: #0b1220;
-  color: #e2e8f0;
-  border: 1px solid rgba(226, 232, 240, 0.08);
-  border-radius: 12px;
-  padding: 16px;
-}
-
-.stat-card h3 {
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  margin: 0 0 6px;
-  color: #93c5fd;
-}
-
-.stat-card p {
-  font-size: 24px;
-  font-weight: 700;
-  margin: 0;
-}
-
-.pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  background: rgba(255,255,255,0.15);
-  color: #fff;
-  border-radius: 999px;
-  padding: 6px 10px;
-  font-size: 12px;
-}
+/* Accentos por métrica */
+.stat-invited { border-color: rgba(14,165,234,0.25); }
+.stat-invited .stat-top .bi, .stat-invited h3 { color: #7dd3fc; }
+.stat-owned { border-color: rgba(34,197,94,0.25); }
+.stat-owned .stat-top .bi, .stat-owned h3 { color: #86efac; }
+.stat-total { border-color: rgba(168,85,247,0.25); }
+.stat-total .stat-top .bi, .stat-total h3 { color: #d8b4fe; }
+.stat-next { border-color: rgba(245,158,11,0.25); }
+.stat-next .stat-top .bi, .stat-next h3 { color: #fcd34d; }

--- a/frontend/src/app/pages/create-event/create-event.html
+++ b/frontend/src/app/pages/create-event/create-event.html
@@ -1,27 +1,39 @@
-<div class="container mt-4" style="max-width:720px;">
-  <h1 class="mb-3">Crear evento</h1>
+<div class="container ce-wrapper">
+  <div class="ce-card">
+    <h1 class="ce-title"><span class="bi bi-calendar-plus"></span> Crear evento</h1>
 
-  <form (ngSubmit)="submit()" #f="ngForm" novalidate>
-    <div class="mb-3">
-      <label class="form-label">Título</label>
-      <input class="form-control" name="title" [(ngModel)]="title" required minlength="2" maxlength="100" />
-    </div>
+    <form (ngSubmit)="submit()" #f="ngForm" novalidate>
+      <div class="form-floating mb-3 position-relative">
+        <input class="form-control" id="ce-title" placeholder="Título" name="title" [(ngModel)]="title" (ngModelChange)="onTitleInput($event)" required minlength="2" maxlength="100" />
+        <label for="ce-title">Título</label>
+        <span *ngIf="emojiHint" class="position-absolute" style="right:12px; top:12px; font-size:18px;">{{ emojiHint }}</span>
+      </div>
 
-    <div class="mb-3">
-      <label class="form-label">Fecha</label>
-      <input type="datetime-local" class="form-control" name="date" [(ngModel)]="date" required />
-    </div>
+      <div class="input-icon mb-3">
+        <i class="bi bi-calendar-event"></i>
+        <input type="datetime-local" class="form-control" name="date" [(ngModel)]="date" required />
+      </div>
 
-    <div class="mb-3">
-      <label class="form-label">Lugar</label>
-      <input class="form-control" name="location" [(ngModel)]="location" required minlength="2" maxlength="100" />
-    </div>
+      <div class="form-floating mb-3">
+        <input class="form-control" id="ce-location" placeholder="Lugar" name="location" [(ngModel)]="location" required minlength="2" maxlength="100" />
+        <label for="ce-location">Lugar</label>
+      </div>
 
-    <div *ngIf="error" class="alert alert-danger">{{ error }}</div>
+      <div *ngIf="error" class="alert alert-danger">{{ error }}</div>
 
-    <div class="d-flex gap-2">
-      <button class="btn btn-light" type="submit">Crear</button>
-      <a routerLink="/" class="btn btn-outline-light">Cancelar</a>
-    </div>
-  </form>
+      <div class="ce-actions">
+        <button class="btn btn-gradient" type="submit" [disabled]="loading">
+          <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" *ngIf="loading"></span>
+          <span class="bi" [ngClass]="loading ? 'bi-hourglass-split' : 'bi-check-circle'"></span>
+          &nbsp;{{ loading ? 'Creando…' : 'Crear' }}
+        </button>
+        <a routerLink="/" class="btn btn-outline-light"><span class="bi bi-x-circle"></span>&nbsp;Cancelar</a>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div *ngIf="ok" class="toast-ok"><span class="bi bi-check-circle"></span> Evento creado correctamente</div>
+<div *ngIf="ok" class="confetti">
+  <i *ngFor="let c of confettiPieces" [ngStyle]="{ left: c.left, top: '0px', background: c.background }"></i>
 </div>

--- a/frontend/src/app/pages/create-event/create-event.html
+++ b/frontend/src/app/pages/create-event/create-event.html
@@ -1,4 +1,27 @@
-<div class="container mt-4">
-  <h1>Crear evento</h1>
-  <p>Próximamente: formulario para crear un nuevo evento.</p>
+<div class="container mt-4" style="max-width:720px;">
+  <h1 class="mb-3">Crear evento</h1>
+
+  <form (ngSubmit)="submit()" #f="ngForm" novalidate>
+    <div class="mb-3">
+      <label class="form-label">Título</label>
+      <input class="form-control" name="title" [(ngModel)]="title" required minlength="2" maxlength="100" />
+    </div>
+
+    <div class="mb-3">
+      <label class="form-label">Fecha</label>
+      <input type="datetime-local" class="form-control" name="date" [(ngModel)]="date" required />
+    </div>
+
+    <div class="mb-3">
+      <label class="form-label">Lugar</label>
+      <input class="form-control" name="location" [(ngModel)]="location" required minlength="2" maxlength="100" />
+    </div>
+
+    <div *ngIf="error" class="alert alert-danger">{{ error }}</div>
+
+    <div class="d-flex gap-2">
+      <button class="btn btn-light" type="submit">Crear</button>
+      <a routerLink="/" class="btn btn-outline-light">Cancelar</a>
+    </div>
+  </form>
 </div>

--- a/frontend/src/app/pages/create-event/create-event.scss
+++ b/frontend/src/app/pages/create-event/create-event.scss
@@ -1,0 +1,64 @@
+.ce-wrapper { display: grid; place-items: start center; padding: 32px 0; }
+.ce-card {
+  width: 100%; max-width: 600px; padding: 22px 20px; border-radius: 0.75rem;
+  background: linear-gradient(180deg, rgba(15,23,42,0.95) 0%, rgba(11,18,32,0.95) 100%);
+  border: 1px solid rgba(148,163,184,0.15);
+  box-shadow: 0 16px 40px rgba(0,0,0,0.28);
+}
+.ce-title { display:flex; align-items:center; gap:10px; margin: 0 0 14px; font-weight: 700; }
+.ce-title .bi { color: #93c5fd; font-size: 22px; }
+
+/* Floating inputs (uses Bootstrap if present; otherwise minimal fallback) */
+.form-floating > .form-control,
+.form-floating > input[type="datetime-local"] {
+  background: #0b1220; color: var(--text); border:1px solid rgba(148,163,184,0.22);
+  border-radius: 0.75rem; transition: all .2s ease;
+}
+.form-floating > label { color: #94a3b8; }
+.form-control:hover { border-color: rgba(99,102,241,0.45); }
+.form-control:focus { border-color: rgba(99,102,241,0.6); box-shadow: 0 0 0 .2rem rgba(99,102,241,0.15); background:#0b1220; }
+
+/* Date input with icon */
+.input-icon { position: relative; }
+.input-icon .bi { position:absolute; left: 12px; top: 50%; transform: translateY(-50%); color:#94a3b8; pointer-events:none; }
+.input-icon input {
+  padding-left: 38px; background:#0b1220; color: var(--text);
+  border:1px solid rgba(148,163,184,0.22); border-radius: 0.75rem; transition: all .2s ease;
+}
+.input-icon input:hover { border-color: rgba(99,102,241,0.45); }
+.input-icon input:focus { border-color: rgba(99,102,241,0.6); box-shadow: 0 0 0 .2rem rgba(99,102,241,0.15); }
+
+.ce-actions { display:flex; gap:10px; }
+.btn-gradient {
+  background: linear-gradient(135deg, var(--primary-2) 0%, var(--primary) 100%);
+  border: 0; color: #0b1220; font-weight: 700;
+}
+.btn-gradient:hover { filter: brightness(1.05); transform: translateY(-1px); box-shadow: 0 0 22px rgba(99,102,241,0.25); }
+.btn { transition: all .2s ease; border-radius: 0.75rem; }
+.btn-outline-light:hover { background: rgba(255,255,255,0.12); border-color: rgba(255,255,255,0.55); }
+
+.alert { border-radius: 12px; }
+
+/* Toast */
+.toast-ok {
+  position: fixed; right: 16px; bottom: 16px; z-index: 60;
+  background: #0b1220; color: var(--text); border:1px solid rgba(148,163,184,0.18);
+  padding: 12px 14px; border-radius: 12px; display:flex; align-items:center; gap:8px;
+  box-shadow: 0 16px 40px rgba(0,0,0,0.28);
+}
+.toast-ok .bi { color: #86efac; }
+
+/* Confetti (simple) */
+.confetti {
+  position: fixed; inset: 0; pointer-events: none; z-index: 70;
+}
+.confetti i {
+  position: absolute; width: 8px; height: 8px; border-radius: 2px;
+  background: linear-gradient(135deg, #7dd3fc, #c7d2fe);
+  animation: fall 1.2s ease-in forwards;
+}
+@keyframes fall {
+  0% { transform: translateY(-20px) rotate(0deg); opacity: 0; }
+  20% { opacity: 1; }
+  100% { transform: translateY(60vh) rotate(240deg); opacity: 0; }
+}

--- a/frontend/src/app/pages/create-event/create-event.ts
+++ b/frontend/src/app/pages/create-event/create-event.ts
@@ -1,11 +1,36 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { EventService } from '../../services/event.service';
 
 @Component({
   selector: 'app-create-event',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule, RouterLink],
   templateUrl: './create-event.html',
   styleUrls: []
 })
-export class CreateEventPage {}
+export class CreateEventPage {
+  title = '';
+  date = '';
+  location = '';
+  error = '';
+
+  constructor(private eventService: EventService, private router: Router) {}
+
+  async submit() {
+    this.error = '';
+    if (!this.title || !this.date || !this.location) {
+      this.error = 'Todos los campos son obligatorios';
+      return;
+    }
+    try {
+      await this.eventService.createEvent({ title: this.title.trim(), date: this.date, location: this.location.trim() });
+      this.router.navigate(['/']);
+    } catch (err: any) {
+      const msg = err?.error?.error || 'No se pudo crear el evento';
+      this.error = msg;
+    }
+  }
+}

--- a/frontend/src/app/pages/create-event/create-event.ts
+++ b/frontend/src/app/pages/create-event/create-event.ts
@@ -9,13 +9,31 @@ import { EventService } from '../../services/event.service';
   standalone: true,
   imports: [CommonModule, FormsModule, RouterLink],
   templateUrl: './create-event.html',
-  styleUrls: []
+  styleUrls: ['./create-event.scss']
 })
 export class CreateEventPage {
   title = '';
   date = '';
   location = '';
   error = '';
+  ok = false;
+  emojiHint = '';
+  loading = false;
+  confettiPieces: { left: string; background: string }[] = [];
+
+  private generateConfetti(count = 24) {
+    const colors = [
+      ['#7dd3fc', '#c7d2fe'],
+      ['#86efac', '#c7d2fe'],
+      ['#fcd34d', '#fda4af']
+    ];
+    this.confettiPieces = Array.from({ length: count }).map(() => {
+      const c = colors[Math.floor(Math.random() * colors.length)];
+      const left = `${Math.random() * 100}%`;
+      const background = `linear-gradient(135deg, ${c[0]}, ${c[1]})`;
+      return { left, background };
+    });
+  }
 
   constructor(private eventService: EventService, private router: Router) {}
 
@@ -26,11 +44,24 @@ export class CreateEventPage {
       return;
     }
     try {
+      this.loading = true;
       await this.eventService.createEvent({ title: this.title.trim(), date: this.date, location: this.location.trim() });
-      this.router.navigate(['/']);
+      this.ok = true; this.title = ''; this.date = ''; this.location = '';
+      this.generateConfetti();
+  this.loading = false;
+  setTimeout(() => this.router.navigate(['/']), 1200);
     } catch (err: any) {
       const msg = err?.error?.error || 'No se pudo crear el evento';
       this.error = msg;
+  this.loading = false;
     }
+  }
+
+  onTitleInput(val: string) {
+    const v = val.toLowerCase();
+    if (v.includes('cumple')) this.emojiHint = '🎉';
+    else if (v.includes('yoga')) this.emojiHint = '🧘';
+    else if (v.includes('reunión') || v.includes('reunion')) this.emojiHint = '🤝';
+    else this.emojiHint = '';
   }
 }

--- a/frontend/src/app/pages/home/home.html
+++ b/frontend/src/app/pages/home/home.html
@@ -1,14 +1,61 @@
 <div *ngIf="!isLoggedIn">
   <div class="container mt-5">
-    <div class="hero text-center">
-      <h1 class="mb-2">POV WebApp</h1>
-      <p class="lead mb-3">Organiza, invita y mide el desempeño de tus eventos.</p>
-      <div class="d-flex justify-content-center gap-2">
-        <a routerLink="/login" class="btn btn-light btn-lg">Iniciar sesión</a>
-        <a routerLink="/register" class="btn btn-outline-light btn-lg">Registrate</a>
+    <section class="landing-hero">
+      <div class="hero-inner">
+        <div class="hero-copy">
+          <h1>POV WebApp</h1>
+          <p class="subtitle">La forma moderna de crear eventos, invitar participantes y revivir de la mejor manera esos momentos únicos.</p>
+          <div class="cta">
+            <a routerLink="/login" class="btn btn-gradient btn-lg"><span class="bi bi-door-open"></span> Iniciar sesión</a>
+            <a routerLink="/register" class="btn btn-outline-light btn-lg"><span class="bi bi-person-plus"></span> Registrate</a>
+          </div>
+        </div>
+        <div class="hero-art" aria-hidden="true">
+          <div class="calendar-art">
+            <div class="cal-header">
+              <span class="dot"></span>
+              <span class="dot"></span>
+              <span class="dot"></span>
+            </div>
+            <div class="cal-grid">
+              <span class="cell today"></span>
+              <span class="cell event"></span>
+              <span class="cell"></span>
+              <span class="cell"></span>
+              <span class="cell event"></span>
+              <span class="cell"></span>
+              <span class="cell"></span>
+            </div>
+          </div>
+          <div class="bubbles">
+            <i></i><i></i><i></i>
+          </div>
+        </div>
       </div>
-    </div>
+    </section>
+
+    <section class="about fade-in">
+      <h2 class="about-title">Acerca</h2>
+      <div class="about-grid">
+        <article class="about-card">
+          <div class="icon"><span class="bi bi-calendar-event"></span></div>
+          <h3>Crear y organiza eventos fácilmente</h3>
+          <p>Define fecha, lugar y detalles en segundos. Invita a tus amigos con un solo clic y mantén todo bajo control en una interfaz moderna y simple.</p>
+        </article>
+        <article class="about-card">
+          <div class="icon"><span class="bi bi-person-check"></span></div>
+          <h3>Participa y comparte tu experiencia</h3>
+          <p>Confirma tu asistencia, recibe recordatorios y captura los mejores momentos del evento para revivirlos después junto a los demás.</p>
+        </article>
+        <article class="about-card">
+          <div class="icon"><span class="bi bi-bar-chart"></span></div>
+          <h3>Revive tu POV</h3>
+          <p>Accede a todos los puntos de vista de cada evento al que asististe y guarda los recuerdos más importantes de manera organizada y segura.</p>
+        </article>
+      </div>
+    </section>
   </div>
+  <div class="spacer" style="height: 16px;"></div>
 </div>
 
 <div *ngIf="isLoggedIn">

--- a/frontend/src/app/pages/home/home.html
+++ b/frontend/src/app/pages/home/home.html
@@ -25,16 +25,21 @@
 
     <div class="spacer"></div>
 
-    <div style="display:grid; grid-template-columns: 1fr 320px; gap: 16px; align-items:start;">
+    <div style="display:grid; grid-template-columns: 2fr 1fr; gap: 16px; align-items:start;">
       <div>
-        <h2 class="section-title"><span class="bi bi-person-check"></span> Invitaciones</h2>
-        <div class="grid">
-          <app-event-card *ngFor="let event of invitedEvents" [event]="event" [isOwner]="false"></app-event-card>
-        </div>
-
-        <h2 class="section-title mt-4"><span class="bi bi-star"></span> Tus eventos</h2>
-        <div class="grid">
-          <app-event-card *ngFor="let event of ownedEvents" [event]="event" [isOwner]="true"></app-event-card>
+        <div class="lists-grid">
+          <section>
+            <h2 class="section-title"><span class="bi bi-star"></span> Tus eventos</h2>
+            <div class="grid">
+              <app-event-card *ngFor="let event of ownedEvents" [event]="event" [isOwner]="true" (invite)="onInvite($event)"></app-event-card>
+            </div>
+          </section>
+          <section>
+            <h2 class="section-title"><span class="bi bi-person-check"></span> Invitaciones</h2>
+            <div class="grid">
+              <app-event-card *ngFor="let event of invitedEvents" [event]="event" [isOwner]="false"></app-event-card>
+            </div>
+          </section>
         </div>
       </div>
 

--- a/frontend/src/app/pages/home/home.scss
+++ b/frontend/src/app/pages/home/home.scss
@@ -1,10 +1,41 @@
-.hero {
-  background: linear-gradient(135deg, #0ea5ea 0%, #4f46e5 100%);
-  color: #fff;
-  border-radius: 16px;
-  padding: 48px 32px;
-  box-shadow: 0 10px 30px rgba(79, 70, 229, 0.25);
+/* --- Logged-out landing styles --- */
+.landing-hero {
+  background: linear-gradient(135deg, rgba(34,211,238,0.15), rgba(99,102,241,0.18));
+  border: 1px solid rgba(148,163,184,0.18);
+  border-radius: 18px;
+  padding: 36px 28px;
+  box-shadow: 0 18px 40px rgba(0,0,0,0.28);
 }
+.hero-inner { display: grid; grid-template-columns: 1.2fr 1fr; align-items: center; gap: 22px; }
+@media (max-width: 900px) { .hero-inner { grid-template-columns: 1fr; } }
+.hero-copy h1 { margin: 0 0 8px; font-weight: 800; font-size: 40px; letter-spacing: 0.2px; }
+.hero-copy .subtitle { opacity: 0.9; margin: 0 0 16px; font-size: 18px; color: #e5e7eb; }
+.cta { display: flex; gap: 10px; align-items: center; }
+
+.hero-art { position: relative; height: 230px; }
+.calendar-art { position: absolute; right: 0; top: 0; width: 290px; background: rgba(11,18,32,0.9); border: 1px solid rgba(148,163,184,0.16); border-radius: 14px; padding: 10px; box-shadow: 0 10px 24px rgba(79,70,229,0.26); }
+.cal-header { display: flex; gap: 6px; margin-bottom: 10px; }
+.cal-header .dot { width: 8px; height: 8px; border-radius: 999px; background: #6366f1; opacity: 0.7; }
+.cal-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 6px; }
+.cal-grid .cell { height: 26px; border-radius: 6px; background: rgba(148,163,184,0.12); border: 1px solid rgba(148,163,184,0.12); }
+.cal-grid .cell.today { outline: 2px solid rgba(99,102,241,0.5); background: rgba(99,102,241,0.2); }
+.cal-grid .cell.event { position: relative; }
+.cal-grid .cell.event::after { content: ''; position: absolute; right: 6px; top: 6px; width: 6px; height: 6px; border-radius: 999px; background: #22d3ee; box-shadow: 0 0 8px rgba(34,211,238,0.8); }
+.bubbles { position: absolute; left: -16px; bottom: -10px; }
+.bubbles i { display:inline-block; width: 12px; height: 12px; border-radius: 999px; background: rgba(255,255,255,0.14); margin: 0 6px; animation: bub 6s ease-in-out infinite; }
+.bubbles i:nth-child(2) { width: 9px; height: 9px; animation-delay: .8s; }
+.bubbles i:nth-child(3) { width: 14px; height: 14px; animation-delay: 1.4s; }
+@keyframes bub { 0%{ transform: translateY(0)} 50%{ transform: translateY(-8px)} 100%{ transform: translateY(0)} }
+
+.about { margin-top: 20px; padding: 16px; background: linear-gradient(180deg, rgba(15,23,42,0.75), rgba(11,18,32,0.75)); border: 1px solid rgba(148,163,184,0.14); border-radius: 14px; }
+.about-title { margin: 0 0 12px; }
+.about-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+@media (max-width: 900px) { .about-grid { grid-template-columns: 1fr; } }
+.about-card { background: rgba(255,255,255,0.06); border: 1px solid rgba(148,163,184,0.12); border-radius: 12px; padding: 16px; transition: transform .2s ease, box-shadow .25s ease, border-color .2s ease; }
+.about-card:hover { transform: translateY(-3px); border-color: rgba(99,102,241,0.35); box-shadow: 0 14px 34px rgba(79,70,229,0.22); }
+.about-card .icon { width: 36px; height: 36px; display: inline-flex; align-items: center; justify-content: center; border-radius: 10px; background: linear-gradient(135deg, rgba(34,211,238,0.22), rgba(99,102,241,0.22)); border: 1px solid rgba(148,163,184,0.2); margin-bottom: 8px; }
+.about-card h3 { margin: 0 0 6px; font-size: 16px; }
+.about-card p { margin: 0; color: #cbd5e1; opacity: 0.9; }
 
 .section-title {
   display: flex;

--- a/frontend/src/app/pages/home/home.scss
+++ b/frontend/src/app/pages/home/home.scss
@@ -16,8 +16,8 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 12px;
 }
 
 .stats {
@@ -62,7 +62,19 @@
   font-size: 12px;
 }
 
-.spacer {
-  height: 8px;
+.spacer { height: 4px; }
+
+/* Side-by-side lists to keep Invitaciones higher on the page */
+.lists-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 992px) {
+  .lists-grid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
 }
 

--- a/frontend/src/app/pages/home/home.ts
+++ b/frontend/src/app/pages/home/home.ts
@@ -61,4 +61,10 @@ export class Home implements OnInit {
   get allEvents(): Event[] {
     return [...this.invitedEvents, ...this.ownedEvents];
   }
+
+  onInvite(eventId: string) {
+    // Placeholder: aquí luego abriremos un modal/página para invitar usuarios al evento
+    console.log('Invitar a evento:', eventId);
+    // TODO: navegar a /event/:id/invite o abrir modal
+  }
 }

--- a/frontend/src/app/pages/home/home.ts
+++ b/frontend/src/app/pages/home/home.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterLink } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { EventService } from '../../services/event.service';
 import { Event } from '../../models/event.model';
 import { EventCard } from '../../components/event-card/event-card';
@@ -20,7 +20,7 @@ export class Home implements OnInit {
   invitedEvents: Event[] = [];
   ownedEvents: Event[] = [];
 
-  constructor(private eventService: EventService, private authService: AuthService) {}
+  constructor(private eventService: EventService, private authService: AuthService, private router: Router) {}
 
   loadEvents() {
     this.eventService.getUserEvents().then((events) => {
@@ -63,8 +63,8 @@ export class Home implements OnInit {
   }
 
   onInvite(eventId: string) {
-    // Placeholder: aquí luego abriremos un modal/página para invitar usuarios al evento
-    console.log('Invitar a evento:', eventId);
-    // TODO: navegar a /event/:id/invite o abrir modal
+  const ev = this.ownedEvents.find(e => e.id === eventId);
+  const title = ev?.title ?? '';
+  this.router.navigate(['/event', eventId, 'invite'], { queryParams: { title } });
   }
 }

--- a/frontend/src/app/pages/invite-event/invite-event.html
+++ b/frontend/src/app/pages/invite-event/invite-event.html
@@ -1,0 +1,33 @@
+<div class="container mt-4">
+  <div class="invite-card">
+  <h2 class="mb-2"><span class="bi bi-person-plus"></span> Invitar al evento</h2>
+  <p class="muted">Evento: <strong>{{ eventTitle || ('#' + eventId) }}</strong></p>
+
+    <div class="chip-input">
+      <div class="chips">
+        <span class="chip" *ngFor="let mail of invitedEmails; let i = index">
+          <span class="bi bi-envelope me-1"></span>{{ mail }}
+          <button type="button" class="chip__remove" (click)="removeEmail(i)" aria-label="Quitar">
+            <span class="bi bi-x"></span>
+          </button>
+        </span>
+      </div>
+      <input
+        type="text"
+        placeholder="Agregar emails (Enter o coma para confirmar)"
+        [(ngModel)]="emailInput"
+        (keydown)="onEmailKeydown($event)"
+      />
+      <button class="btn btn-light" (click)="addEmail()"><span class="bi bi-plus"></span> Agregar</button>
+    </div>
+
+    <div class="actions">
+      <a class="btn btn-outline-light" [routerLink]="['/']"><span class="bi bi-arrow-left"></span> Volver</a>
+      <button class="btn btn-gradient" [disabled]="invitedEmails.length === 0" (click)="saveInvites()">
+        <span class="bi bi-send"></span> Guardar invitaciones
+      </button>
+    </div>
+
+    <div class="toast-ok" *ngIf="message">{{ message }}</div>
+  </div>
+</div>

--- a/frontend/src/app/pages/invite-event/invite-event.scss
+++ b/frontend/src/app/pages/invite-event/invite-event.scss
@@ -1,0 +1,72 @@
+.invite-card {
+  background: linear-gradient(135deg, rgba(255,255,255,0.12), rgba(255,255,255,0.06));
+  border-radius: 14px;
+  padding: 20px;
+  box-shadow: 0 8px 30px rgba(0,0,0,0.25);
+  border: 1px solid rgba(255,255,255,0.15);
+}
+
+.muted { opacity: 0.8; }
+
+.chip-input {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: start;
+  margin: 16px 0 6px;
+}
+
+.chip-input input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.25);
+  background: rgba(255,255,255,0.08);
+  color: #fff;
+}
+
+.chips {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.12);
+  border: 1px solid rgba(255,255,255,0.16);
+}
+
+.chip__remove {
+  background: transparent;
+  border: none;
+  color: inherit;
+  padding: 0 2px;
+  cursor: pointer;
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 16px;
+}
+
+.btn.btn-gradient {
+  background: linear-gradient(135deg, #22d3ee, #6366f1);
+  color: #0b1220;
+  border: none;
+}
+
+.toast-ok {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(34, 197, 94, 0.18);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+}

--- a/frontend/src/app/pages/invite-event/invite-event.ts
+++ b/frontend/src/app/pages/invite-event/invite-event.ts
@@ -1,0 +1,61 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-invite-event',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  templateUrl: './invite-event.html',
+  styleUrls: ['./invite-event.scss']
+})
+export class InviteEventPage implements OnInit {
+  eventId: string = '';
+  eventTitle: string = '';
+  emailInput: string = '';
+  invitedEmails: string[] = [];
+  message: string = '';
+
+  constructor(private route: ActivatedRoute, private router: Router) {}
+
+  ngOnInit(): void {
+    this.eventId = this.route.snapshot.paramMap.get('id') || '';
+    this.eventTitle = this.route.snapshot.queryParamMap.get('title') || '';
+  }
+
+  addEmail(): void {
+    const raw = (this.emailInput || '').trim();
+    if (!raw) return;
+    // allow comma-separated batch
+    const parts = raw.split(',').map((p) => p.trim()).filter(Boolean);
+    for (const p of parts) {
+      if (this.isValidEmail(p) && !this.invitedEmails.includes(p)) {
+        this.invitedEmails.push(p);
+      }
+    }
+    this.emailInput = '';
+  }
+
+  onEmailKeydown(ev: KeyboardEvent): void {
+    if (ev.key === 'Enter' || ev.key === ',') {
+      ev.preventDefault();
+      this.addEmail();
+    }
+  }
+
+  removeEmail(i: number): void {
+    this.invitedEmails.splice(i, 1);
+  }
+
+  saveInvites(): void {
+    // Backend not ready yet: just show a friendly message and log payload
+    const payload = { eventId: this.eventId, invitees: this.invitedEmails };
+    console.log('Draft invites (to be sent when backend is ready):', payload);
+    this.message = 'Invitaciones preparadas. Se enviarán cuando el backend esté listo.';
+  }
+
+  private isValidEmail(e: string): boolean {
+    return /.+@.+\..+/.test(e);
+  }
+}

--- a/frontend/src/app/services/event.service.ts
+++ b/frontend/src/app/services/event.service.ts
@@ -4,7 +4,8 @@ import { firstValueFrom } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class EventService {
-  private apiUrl = 'http://localhost:3000/events';
+  private eventsUrl = 'http://localhost:3000/events';
+  private eventUrl = 'http://localhost:3000/event';
 
   constructor(private http: HttpClient) {}
 
@@ -14,7 +15,18 @@ export class EventService {
       Authorization: `Bearer ${token}`
     });
     return firstValueFrom(
-      this.http.get<{owner: Event[], invited: Event[]}>(this.apiUrl, { headers })
+      this.http.get<{owner: Event[], invited: Event[]}>(this.eventsUrl, { headers })
+    );
+  }
+
+  createEvent(payload: { title: string; date: string; location: string }): Promise<void> {
+    const token = localStorage.getItem('token');
+    const headers = new HttpHeaders({
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    });
+    return firstValueFrom(
+      this.http.post<void>(this.eventUrl, payload, { headers })
     );
   }
 }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -11,5 +11,10 @@
 </head>
 <body>
   <app-root></app-root>
+  <footer class="app-footer">
+    <a href="https://www.linkedin.com/in/joaquin-kalichman" target="_blank" rel="noopener" aria-label="LinkedIn Joaquín Kalichman" class="footer-link">
+      <span class="bi bi-linkedin"></span>
+    </a>
+  </footer>
 </body>
 </html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,16 +1,12 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
-import { provideRouter } from '@angular/router';
-import { routes } from './app/app.routes';
 import { HttpClientModule } from '@angular/common/http';
 import { importProvidersFrom } from '@angular/core';
 
 bootstrapApplication(App, {
   providers: [
-    provideRouter(routes),
     importProvidersFrom(HttpClientModule),
-    ...appConfig.providers,
-    HttpClientModule
+    ...appConfig.providers
   ]
 }).catch((err) => console.error(err));

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -89,6 +89,7 @@ section { margin-bottom: 22px; }
 		-webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
 		mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
 	-webkit-mask-composite: xor; mask-composite: exclude;
+	pointer-events: none;
 	opacity: 0; transition: opacity .2s ease;
 }
 .ev-card:hover::before { opacity: 1; }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -14,10 +14,19 @@ html, body { height: 100%; }
 body {
 	margin: 0;
 	font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
-	background: radial-gradient(1200px 800px at 10% -10%, rgba(14,165,234,0.15) 0%, transparent 60%),
-							radial-gradient(1000px 700px at 110% -20%, rgba(79,70,229,0.15) 0%, transparent 60%),
-							var(--bg);
+	background:
+		radial-gradient(1200px 800px at 10% -10%, rgba(14,165,234,0.12) 0%, transparent 60%),
+		radial-gradient(1000px 700px at 110% -20%, rgba(79,70,229,0.12) 0%, transparent 60%),
+		linear-gradient(120deg, #0b1220, #0f172a 40%, #0b1220);
 	color: var(--text);
+	background-size: 160% 160%, 160% 160%, 100% 100%;
+	animation: bgMove 18s ease-in-out infinite;
+}
+
+@keyframes bgMove {
+	0% { background-position: 0% 0%, 100% 0%, 0% 0%; }
+	50% { background-position: 20% 10%, 80% 5%, 0% 0%; }
+	100% { background-position: 0% 0%, 100% 0%, 0% 0%; }
 }
 
 .container {
@@ -66,12 +75,23 @@ section { margin-bottom: 22px; }
 	padding: 14px 16px;
 	box-shadow: 0 6px 18px rgba(0,0,0,0.22);
 	transition: transform 0.2s ease, box-shadow 0.25s ease, border-color 0.2s ease, filter 0.2s ease;
+		position: relative;
 }
 .ev-card:hover {
 	transform: translateY(-3px) scale(1.01);
 	border-color: rgba(99,102,241,0.5);
 	box-shadow: 0 14px 34px rgba(79,70,229,0.28);
 }
+.ev-card::before {
+	content: '';
+	position: absolute; inset: 0; border-radius: inherit; padding: 1px;
+	background: linear-gradient(135deg, rgba(14,165,234,0.25), rgba(79,70,229,0.25));
+		-webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+		mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+	-webkit-mask-composite: xor; mask-composite: exclude;
+	opacity: 0; transition: opacity .2s ease;
+}
+.ev-card:hover::before { opacity: 1; }
 .ev-card__title { margin: 0 0 8px; font-weight: 700; }
 .ev-card__meta {
 	display: flex;
@@ -117,6 +137,25 @@ section { margin-bottom: 22px; }
 
 /* Bootstrap icons helper (if BI present) */
 .bi { display: inline-block; }
+
+/* Subtle decorative SVGs in background */
+body::before, body::after {
+	content: '';
+	position: fixed; z-index: 0; pointer-events: none; opacity: 0.06;
+	filter: blur(1px);
+}
+body::before {
+	inset: auto auto 10% -40px; width: 200px; height: 200px;
+	background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 24 24" fill="%23c7d2fe"><path d="M6 2h12v2H6zM5 6h14v2H5zM4 10h16v10H4z"/></svg>') no-repeat center/contain;
+	animation: floatA 14s ease-in-out infinite;
+}
+body::after {
+	inset: 5% -40px auto auto; width: 160px; height: 160px;
+	background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 24 24" fill="%237dd3fc"><path d="M12 17.27L18.18 21 16.54 13.97 22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24 7.46 13.97 5.82 21z"/></svg>') no-repeat center/contain;
+	animation: floatB 18s ease-in-out infinite;
+}
+@keyframes floatA { 0% { transform: translateY(0px) rotate(0deg); } 50% { transform: translateY(-10px) rotate(5deg);} 100% { transform: translateY(0px) rotate(0deg);} }
+@keyframes floatB { 0% { transform: translateY(0px) rotate(0deg); } 50% { transform: translateY(8px) rotate(-4deg);} 100% { transform: translateY(0px) rotate(0deg);} }
 
 /* Footer */
 .app-footer { position: fixed; right: 14px; bottom: 14px; z-index: 50; }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -54,6 +54,14 @@ section { margin-bottom: 22px; }
 	font-weight: 600;
 	text-decoration: none;
 }
+.btn-lg { padding: 12px 18px; font-size: 1.05rem; }
+.btn-gradient {
+	background: linear-gradient(135deg, #22d3ee, #6366f1);
+	color: #0b1220;
+	border: none;
+	box-shadow: 0 10px 24px rgba(79,70,229,0.25);
+}
+.btn-gradient:hover { filter: brightness(1.02); box-shadow: 0 14px 34px rgba(79,70,229,0.32); transform: translateY(-1px); }
 .btn-light {
 	background: #fff;
 	color: #0f172a;

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -26,6 +26,13 @@ body {
 	padding: 0 16px;
 }
 
+/* Headings and spacing */
+h1, h2, h3 { font-weight: 600; letter-spacing: 0.2px; }
+h2 { color: #e5e7eb; }
+h3 { color: #cbd5e1; }
+section { margin-bottom: 22px; }
+.hero { padding: 56px 36px; border-radius: 16px; }
+
 .btn-primary, .btn-light, .btn-outline-light {
 	border-radius: 10px;
 }
@@ -53,17 +60,17 @@ body {
 
 /* Event card */
 .ev-card {
-	background: var(--surface);
+	background: linear-gradient(180deg, rgba(15,23,42,1) 0%, rgba(11,18,32,1) 100%);
 	border: 1px solid var(--border);
-	border-radius: 14px;
+	border-radius: 0.75rem;
 	padding: 14px 16px;
-	box-shadow: 0 6px 20px rgba(0,0,0,0.25);
-	transition: transform 0.15s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+	box-shadow: 0 6px 18px rgba(0,0,0,0.22);
+	transition: transform 0.2s ease, box-shadow 0.25s ease, border-color 0.2s ease, filter 0.2s ease;
 }
 .ev-card:hover {
-	transform: translateY(-2px);
-	border-color: rgba(99,102,241,0.45);
-	box-shadow: 0 10px 28px rgba(79,70,229,0.25);
+	transform: translateY(-3px) scale(1.01);
+	border-color: rgba(99,102,241,0.5);
+	box-shadow: 0 14px 34px rgba(79,70,229,0.28);
 }
 .ev-card__title { margin: 0 0 8px; font-weight: 700; }
 .ev-card__meta {
@@ -110,3 +117,8 @@ body {
 
 /* Bootstrap icons helper (if BI present) */
 .bi { display: inline-block; }
+
+/* Footer */
+.app-footer { position: fixed; right: 14px; bottom: 14px; z-index: 50; }
+.footer-link { display:inline-flex; align-items:center; justify-content:center; width:38px; height:38px; border-radius:999px; background: rgba(255,255,255,0.1); color:#e2e8f0; border:1px solid rgba(226,232,240,0.15); backdrop-filter: blur(6px); }
+.footer-link:hover { background: rgba(255,255,255,0.18); color:#fff; }


### PR DESCRIPTION
Resumen

Rediseño de la Home para usuarios no logueados con un hero moderno y una sección “Acerca” coherentes con el dashboard y Crear Evento.
Flujo “Invitar”: navegación desde la card del evento del owner hacia una nueva página de invitaciones.
Pequeños refinamientos de UX (botones con gradiente, transiciones, spinner en creación).
Cambios principales

Home (logged-out):
Nuevo hero con gradiente, título/subtítulo, ilustración decorativa y CTAs.
Sección “Acerca” con 3 tarjetas (crear, invitar, medir) e íconos (bi-calendar-event, bi-person-check, bi-bar-chart) con fade-in.
Invitaciones:
Nueva página InviteEventPage en /event/:id/invite con input tipo “chips” para emails.
Home navega pasando el título del evento por query param; EventCard emite “invite”.
Fix de overlay en card para habilitar el click (pointer-events: none).
Crear evento:
Botón “Crear” con estado de carga (spinner y “Creando…”), confetti precomputado.
Estilos globales:
.btn-gradient y ajustes visuales consistentes (gradientes, sombras, bordes, transiciones).
Rutas nuevas

GET /event/:id/invite (frontend): página para preparar invitaciones (sin backend todavía).